### PR TITLE
Add support for time.sleep

### DIFF
--- a/python/time.py
+++ b/python/time.py
@@ -68,8 +68,10 @@ def localtime(seconds = None):
 
     return loctime._replace(tm_yday = ordinaldate)
 
+def sleep(seconds):
+    _bits._sleep_ms(max(int(seconds * 1000), 0))
+
 #mktime
-#sleep
 #strftime
 #strptime
 #struct_time

--- a/rc/python/bitsmodule.c
+++ b/rc/python/bitsmodule.c
@@ -276,6 +276,15 @@ static PyObject *bits__putenv(PyObject *self, PyObject *args)
     return Py_BuildValue("");
 }
 
+static PyObject *bits__sleep_ms(PyObject *self, PyObject *args)
+{
+    uint32_t ms;
+    if (!PyArg_ParseTuple(args, "I", &ms))
+        return NULL;
+    grub_millisleep(ms);
+    return Py_BuildValue("");
+}
+
 static PyObject *bits__stat(PyObject *self, PyObject *args)
 {
     const char *path;
@@ -567,6 +576,7 @@ static PyMethodDef bitsMethods[] = {
     {"_set_readline_callback", bits_set_readline_callback, METH_VARARGS, "_set_readline_callback(callable)"},
     {"_stat", bits__stat, METH_VARARGS, "_stat(path) -> tuple (internal implementation details of stat)"},
     {"_time", bits__time, METH_NOARGS, "_time() -> time in seconds (accurate for relative use only)"},
+    {"_sleep_ms", bits__sleep_ms, METH_VARARGS, "_sleep_ms(ms) -> time to sleep in milliseconds"},
     {"_unsetenv",  bits__unsetenv, METH_VARARGS, "_unsetenv(key): Unset an environment variable"},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };


### PR DESCRIPTION
This adds support for the time modules sleep function. The underlying functionality is provided by `grub_millisleep` in the `_bits` module. The python wrapping stub converts the float of integer value in seconds to milliseconds to be passed to `_bits._sleep_ms`.

Verification steps from the interactive python interpreter:
- [ ] `import time; time.sleep(3)` should run without errors and sleep for 3 seconds
- [ ] `import _bits; _bits._sleep_ms(1000)` should run without errors and sleep for 1 second
